### PR TITLE
Clock improvements plus made DateTimePicker bindable.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -399,3 +399,5 @@ FodyWeavers.xsd
 # output folder
 /output/
 /src/output/
+/dev/DevWinUI.Controls/DevWinUI.Controls.sln
+/.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -399,5 +399,3 @@ FodyWeavers.xsd
 # output folder
 /output/
 /src/output/
-/dev/DevWinUI.Controls/DevWinUI.Controls.sln
-/.gitignore

--- a/dev/DevWinUI.Controls/Controls/Date/CalendarWithClock/CalendarWithClock.cs
+++ b/dev/DevWinUI.Controls/Controls/Date/CalendarWithClock/CalendarWithClock.cs
@@ -25,7 +25,6 @@ public partial class CalendarWithClock : DateTimeBase
     {
         get
         {
-            //return SelectedDateTime.ToString("dd/MM/yyyy");
             return SelectedDateTime.ToString("d");
         }
     }
@@ -33,9 +32,7 @@ public partial class CalendarWithClock : DateTimeBase
     {
         get
         {
-            //return $"{SelectedDateFormatted} - {SelectedTime?.ToString(@"hh\:mm\:ss")}";
             return $"{SelectedDateFormatted} - {SelectedDateTime.TimeOfDay.ToString(@"hh\:mm\:ss")}";
-
         }
     }
 

--- a/dev/DevWinUI.Controls/Controls/Date/CalendarWithClock/CalendarWithClock.cs
+++ b/dev/DevWinUI.Controls/Controls/Date/CalendarWithClock/CalendarWithClock.cs
@@ -25,14 +25,17 @@ public partial class CalendarWithClock : DateTimeBase
     {
         get
         {
-            return SelectedDateTime.ToString("dd/MM/yyyy");
+            //return SelectedDateTime.ToString("dd/MM/yyyy");
+            return SelectedDateTime.ToString("d");
         }
     }
     public string SelectedDateTimeString
     {
         get
         {
-            return $"{SelectedDateFormatted} - {SelectedTime?.ToString(@"hh\:mm\:ss")}";
+            //return $"{SelectedDateFormatted} - {SelectedTime?.ToString(@"hh\:mm\:ss")}";
+            return $"{SelectedDateFormatted} - {SelectedDateTime.TimeOfDay.ToString(@"hh\:mm\:ss")}";
+
         }
     }
 
@@ -71,6 +74,11 @@ public partial class CalendarWithClock : DateTimeBase
 
         if (clock != null)
         {
+            if (SelectedDateTime != default)
+            {
+                clock.SelectedTime = SelectedDateTime.DateTime;
+            }
+
             clock.SelectedTimeChanged -= OnClockSelectedTimeChanged;
             clock.SelectedTimeChanged += OnClockSelectedTimeChanged;
         }
@@ -88,14 +96,12 @@ public partial class CalendarWithClock : DateTimeBase
             {
                 isUpdating = true;
 
-                // Update SelectedTime
                 SelectedTime = new TimeSpan(selectedTime.Hour, selectedTime.Minute, selectedTime.Second);
 
-                // Update SelectedDateTime with new time while preserving the date and time zone offset
                 SelectedDateTime = new DateTimeOffset(
-                    SelectedDateTime.Year, SelectedDateTime.Month, SelectedDateTime.Day,
-                    selectedTime.Hour, selectedTime.Minute, selectedTime.Second,
-                    SelectedDateTime.Offset);
+                    SelectedDateTime.Year, SelectedDateTime.Month, SelectedDateTime.Day,//original
+                    selectedTime.Hour, selectedTime.Minute, selectedTime.Second,  //just updated.
+                    SelectedDateTime.Offset); //original
 
                 SelectedTimeChanged?.Invoke(this, SelectedDateTime);
             }
@@ -135,10 +141,8 @@ public partial class CalendarWithClock : DateTimeBase
             {
                 isUpdating = true;
 
-                // Update SelectedTime
                 SelectedTime = selectedTime;
 
-                // Update SelectedDateTime with new time while preserving the date and time zone offset
                 SelectedDateTime = new DateTimeOffset(
                     SelectedDateTime.Year, SelectedDateTime.Month, SelectedDateTime.Day,
                     selectedTime.Hours, selectedTime.Minutes, selectedTime.Seconds,

--- a/dev/DevWinUI.Controls/Controls/Date/Clock/Clock.cs
+++ b/dev/DevWinUI.Controls/Controls/Date/Clock/Clock.cs
@@ -150,7 +150,6 @@ public partial class Clock : Control
         var pointerPoint = e.GetCurrentPoint(_grid);
         if (pointerPoint.Properties.IsLeftButtonPressed)
         {
-
             //When clicking on a number, don't move the minute hand.
             var originalSource = e.OriginalSource as FrameworkElement;
             if (originalSource is TextBlock) 

--- a/dev/DevWinUI.Controls/Controls/Date/Clock/Clock.cs
+++ b/dev/DevWinUI.Controls/Controls/Date/Clock/Clock.cs
@@ -129,7 +129,10 @@ public partial class Clock : Control
         }
 
         isTemplateApplied = true;
-        //SelectedTime = DateTime.Now; //Commented out, as the SelectedTime already defaults to DateTime.Now, and this interferes with externally set DateTime.
+
+        //As the SelectedTime already defaults to DateTime.Now, and this interferes with externally set DateTime.
+        //SelectedTime = DateTime.Now;
+
         Update(SelectedTime);
     }
 
@@ -148,8 +151,9 @@ public partial class Clock : Control
         if (pointerPoint.Properties.IsLeftButtonPressed)
         {
 
+            //When clicking on a number, don't move the minute hand.
             var originalSource = e.OriginalSource as FrameworkElement;
-            if (originalSource is TextBlock) //When clicking on a number, don't move the minute hand.
+            if (originalSource is TextBlock) 
             {
                 return;
             }
@@ -282,7 +286,9 @@ public partial class Clock : Control
         {
             hourValue = 0;
         }
-        var now = DateTime.Now; //Remember, this does not overwrite CalendarWithClock/DateTimePicker's SelectedDateTime, so no need to switch to TimeOnly and break users' apps.
+
+        //Remember, this does not overwrite CalendarWithClock/DateTimePicker's SelectedDateTime, so no need to switch to TimeOnly and break users' apps.
+        var now = DateTime.Now;
         return new DateTime(now.Year, now.Month, now.Day, hourValue, minuteValue, _secValue);
     }
 


### PR DESCRIPTION
## Clock Changes

- Hour can now be picked without inadvertently changing the minute.  
- Private variable names have been made clearer.

## DateTimePicker changes.

* SelectedDateTime is now bindable, as it no longer needs both a date and time to be provided. 
* SelectedDateFormatted now uses the user's system locale.   AFAIK, all date strings will still be 10 char long, so it won't mess up the visual design.

## Future Suggestions (I can implement them, but you might not want them)
- Maybe make the bubble around the selected hour smaller.
- Maybe have an optional int property for  MinuteIncrement, but this'd make dragging the clock hand seem less responsive 