### PR TITLE
Fix DropDownColorPicker

### DIFF
--- a/dev/DevWinUI/Controls/Native/DropdownColorPicker/DropdownColorPicker.cs
+++ b/dev/DevWinUI/Controls/Native/DropdownColorPicker/DropdownColorPicker.cs
@@ -55,15 +55,19 @@ public partial class DropdownColorPicker : Control
             colorPicker.ColorChanged -= OnColorPickerColorChanged;
             colorPicker.ColorChanged += OnColorPickerColorChanged;
         }
+        if (ColorPalette != null)
+        {
+            ColorPalette.ColorChanged -= OnColorPaletteColorChanged;
+            ColorPalette.ColorChanged += OnColorPaletteColorChanged;
+        }
     }
 
     private void OnDropdownColorPickerUnloaded(object sender, RoutedEventArgs e)
     {
         if (colorPicker != null)
-        {
             colorPicker.ColorChanged -= OnColorPickerColorChanged;
+        if (ColorPalette != null)
             ColorPalette.ColorChanged -= OnColorPaletteColorChanged;
-        }
     }
 
     private void UpdateFlyoutOptions()

--- a/dev/DevWinUI/Controls/Native/DropdownColorPicker/DropdownColorPicker.cs
+++ b/dev/DevWinUI/Controls/Native/DropdownColorPicker/DropdownColorPicker.cs
@@ -42,16 +42,28 @@ public partial class DropdownColorPicker : Control
         UpdateFlyoutOptions();
         OnColorChanged();
 
+        Loaded -= OnDropdownColorPickerLoaded;
+        Loaded += OnDropdownColorPickerLoaded;
         Unloaded -= OnDropdownColorPickerUnlaoded;
         Unloaded += OnDropdownColorPickerUnlaoded;
+    }
+
+    private void OnDropdownColorPickerLoaded(object sender, RoutedEventArgs e)
+    {
+        if (colorPicker != null)
+        {
+            colorPicker.ColorChanged -= OnColorPickerColorChanged;
+            colorPicker.ColorChanged += OnColorPickerColorChanged;
+        }
     }
 
     private void OnDropdownColorPickerUnlaoded(object sender, RoutedEventArgs e)
     {
         if (colorPicker != null)
+        {
             colorPicker.ColorChanged -= OnColorPickerColorChanged;
-        if (ColorPalette != null)
             ColorPalette.ColorChanged -= OnColorPaletteColorChanged;
+        }
     }
 
     private void UpdateFlyoutOptions()

--- a/dev/DevWinUI/Controls/Native/DropdownColorPicker/DropdownColorPicker.cs
+++ b/dev/DevWinUI/Controls/Native/DropdownColorPicker/DropdownColorPicker.cs
@@ -44,8 +44,8 @@ public partial class DropdownColorPicker : Control
 
         Loaded -= OnDropdownColorPickerLoaded;
         Loaded += OnDropdownColorPickerLoaded;
-        Unloaded -= OnDropdownColorPickerUnlaoded;
-        Unloaded += OnDropdownColorPickerUnlaoded;
+        Unloaded -= OnDropdownColorPickerUnloaded;
+        Unloaded += OnDropdownColorPickerUnloaded;
     }
 
     private void OnDropdownColorPickerLoaded(object sender, RoutedEventArgs e)
@@ -57,7 +57,7 @@ public partial class DropdownColorPicker : Control
         }
     }
 
-    private void OnDropdownColorPickerUnlaoded(object sender, RoutedEventArgs e)
+    private void OnDropdownColorPickerUnloaded(object sender, RoutedEventArgs e)
     {
         if (colorPicker != null)
         {


### PR DESCRIPTION
This PR fixes `DropdownColorPicker` color selection breaking after the control has been unloaded and reloaded (e.g., when used inside a `CommandBar` overflow).

**Root cause**: `OnApplyTemplate` hooks `colorPicker.ColorChanged` and `ColorPalette.ColorChanged` once, but the `Unloaded` handler permanently unhooks both. Since `OnApplyTemplate` never runs again, the handlers are never reconnected.

**Fix**: 
- Add a `Loaded` handler that reconnects both `colorPicker.ColorChanged` and `ColorPalette.ColorChanged` every time the control re-enters the visual tree
- Fix typo: `OnDropdownColorPickerUnlaoded` → `OnDropdownColorPickerUnloaded`